### PR TITLE
Plugin name uses underscores and not hypens?

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ functionality.
 Installation
 ------------
 Extract the contents of the zip file into your RabbitMQ plugins directory. Once
-extracted, run ``rabbitmq-plugins enable pgsql-listen-exchange``.
+extracted, run ``rabbitmq-plugins enable pgsql_listen_exchange``.
 
 Configuration
 -------------

--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ You can also change the default connection values in the ``rabbitmq.config`` fil
 | password     | The password to use when connecting  | list      | ""            |
 +--------------+--------------------------------------+-----------+---------------+
 
-*Exaple rabbitmq.config*
+*Example rabbitmq.config*
 
 ..  code-block:: erlang
 


### PR DESCRIPTION
Downloaded, unzipped, moved files to plugins directory and pgsql-listen-exchange couldn't be found. The list of plugins showed:

[  ] pgsql_listen_exchange             3.3.x-0.2.0

Changed to underscores and it worked.