### PR TITLE
Return Channels instead of Bindings

### DIFF
--- a/src/pgsql_listen_lib.erl
+++ b/src/pgsql_listen_lib.erl
@@ -264,7 +264,7 @@ ensure_channel_binding_references(Channel, X, Channels) ->
     {ok, Bindings} ->
       case list_find(X, Bindings) of
         true ->
-          {ok, Bindings};
+          {ok, Channels};
         false ->
           {ok, dict:store(Channel, lists:append(Bindings, [X]), Channels)}
       end;


### PR DESCRIPTION
ensure_channel_binding_references should return Channels instead of Bindings if Excahnge found in list of Bindings

This PR should close #3 